### PR TITLE
Media CRUD tests

### DIFF
--- a/database/factories/MediaFolderFactory.php
+++ b/database/factories/MediaFolderFactory.php
@@ -1,0 +1,11 @@
+<?php
+
+use Faker\Generator as Faker;
+use Optimus\Media\Models\MediaFolder;
+
+$factory->define(MediaFolder::class, function (Faker $faker) {
+    return [
+        'name' => $faker->word,
+        'parent_id' => null,
+    ];
+});

--- a/src/Http/Controllers/FoldersController.php
+++ b/src/Http/Controllers/FoldersController.php
@@ -3,10 +3,11 @@
 namespace Optimus\Media\Http\Controllers;
 
 use Illuminate\Http\Request;
-use Illuminate\Validation\Rule;
 use Illuminate\Routing\Controller;
 use Optimus\Media\Models\MediaFolder;
 use Optimus\Media\Http\Resources\FolderResource;
+use Optimus\Media\Http\Requests\StoreFolderRequest;
+use Optimus\Media\Http\Requests\UpdateFolderRequest;
 
 class FoldersController extends Controller
 {
@@ -17,10 +18,8 @@ class FoldersController extends Controller
         return FolderResource::collection($folders);
     }
 
-    public function store(Request $request)
+    public function store(StoreFolderRequest $request)
     {
-        $this->validateFolder($request);
-
         $folder = MediaFolder::create($request->all());
 
         return new FolderResource($folder);
@@ -33,11 +32,9 @@ class FoldersController extends Controller
         return new FolderResource($folder);
     }
 
-    public function update(Request $request, $id)
+    public function update(UpdateFolderRequest $request, $id)
     {
         $folder = MediaFolder::findOrFail($id);
-
-        $this->validateFolder($request, $folder);
 
         $folder->update($request->all());
 
@@ -53,21 +50,5 @@ class FoldersController extends Controller
         $folder->delete();
 
         return response(null, 204);
-    }
-
-    protected function validateFolder(Request $request, MediaFolder $folder = null)
-    {
-        $request->validate([
-            'name' => $folder ? 'filled' : 'required',
-            'parent_id' => [
-                'nullable',
-                Rule::exists('media_folders', 'id')
-                    ->where(function ($query) use ($folder) {
-                        $query->when($folder, function ($query) use ($folder) {
-                            $query->where('id', '<>', $folder->id);
-                        });
-                    })
-            ]
-        ]);
     }
 }

--- a/src/Http/Controllers/MediaController.php
+++ b/src/Http/Controllers/MediaController.php
@@ -30,7 +30,7 @@ class MediaController extends Controller
             PerformConversions::dispatch($media, ['400x300']);
         }
 
-        return new MediaResource($media);
+        return (new MediaResource($media))->response()->setStatusCode(201);
     }
 
     public function show($id)

--- a/src/Http/Requests/StoreFolderRequest.php
+++ b/src/Http/Requests/StoreFolderRequest.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Optimus\Media\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class StoreFolderRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    public function rules()
+    {
+        return [
+            'name' => [
+                'required',
+            ],
+            'parent_id' => [
+                'nullable',
+                'exists:media_folders,id',
+            ]
+        ];
+    }
+}

--- a/src/Http/Requests/UpdateFolderRequest.php
+++ b/src/Http/Requests/UpdateFolderRequest.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Optimus\Media\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class UpdateFolderRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    public function rules()
+    {
+        return [
+            'name' => 'filled',
+            'parent_id' => [
+                'nullable',
+                'different:id',
+                'exists:media_folders,id'
+            ]
+        ];
+    }
+}

--- a/src/Http/Requests/UpdateMediaRequest.php
+++ b/src/Http/Requests/UpdateMediaRequest.php
@@ -26,7 +26,6 @@ class UpdateMediaRequest extends FormRequest
         return [
             'name' => 'filled',
             'folder_id' => [
-                'required_without:name',
                 'nullable',
                 'exists:media_folders,id'
             ]

--- a/tests/Feature/CreateFolderTest.php
+++ b/tests/Feature/CreateFolderTest.php
@@ -20,10 +20,11 @@ class CreateFolderTest extends TestCase
     /** @test */
     public function it_can_create_a_folder()
     {
-        $response = $this->postJson(
-            route('admin.media-folders.store'),
-            $data = $this->validData()
-        );
+        $data = [
+            'name' => 'New name',
+            'parent_id' => null
+        ];
+        $response = $this->postJson(route('admin.media-folders.store'), $data);
 
         $response
             ->assertStatus(201)
@@ -42,11 +43,39 @@ class CreateFolderTest extends TestCase
         ));
     }
 
-    protected function validData($overrides = [])
+    /** @test */
+    public function it_will_reject_invalid_parent_folder()
     {
-        return array_merge([
+        $data = [
             'name' => 'New name',
+            'parent_id' => 9999
+        ];
+        $response = $this->postJson(route('admin.media-folders.store'), $data);
+
+        $response
+            ->assertStatus(422)
+            ->assertJsonValidationErrors(['parent_id']);
+    }
+
+    /** @test */
+    public function it_will_reject_missing_folder_name()
+    {
+        $response1 = $this->postJson(route('admin.media-folders.store'), [
+            'name' => '',
             'parent_id' => null
-        ], $overrides);
+        ]);
+
+        $response1
+            ->assertStatus(422)
+            ->assertJsonValidationErrors(['name']);
+
+        $response2 = $this->postJson(route('admin.media-folders.store'), [
+            'name' => null,
+            'parent_id' => null
+        ]);
+
+        $response2
+            ->assertStatus(422)
+            ->assertJsonValidationErrors(['name']);
     }
 }

--- a/tests/Feature/CreateFolderTest.php
+++ b/tests/Feature/CreateFolderTest.php
@@ -2,9 +2,9 @@
 
 namespace Optimus\Media\Tests\Feature;
 
-use Illuminate\Foundation\Testing\RefreshDatabase;
-use Optimus\Media\Models\MediaFolder;
 use Optimus\Media\Tests\TestCase;
+use Optimus\Media\Models\MediaFolder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
 
 class CreateFolderTest extends TestCase
 {

--- a/tests/Feature/CreateFolderTest.php
+++ b/tests/Feature/CreateFolderTest.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Optimus\Media\Tests\Feature;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Optimus\Media\Models\MediaFolder;
+use Optimus\Media\Tests\TestCase;
+
+class CreateFolderTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp()
+    {
+        parent::setUp();
+
+        $this->signIn();
+    }
+
+    /** @test */
+    public function it_can_create_a_folder()
+    {
+        $response = $this->postJson(
+            route('admin.media-folders.store'),
+            $data = $this->validData()
+        );
+
+        $response
+            ->assertStatus(201)
+            ->assertJsonStructure([
+                'data' => $this->expectedFolderJsonStructure()
+            ])
+            ->assertJson([
+                'data' => [
+                    'name' => $data['name'],
+                    'parent_id' => $data['parent_id'],
+                ]
+            ]);
+
+        $this->assertNotNull($folder = MediaFolder::find(
+            $response->decodeResponseJson('data.id')
+        ));
+    }
+
+    protected function validData($overrides = [])
+    {
+        return array_merge([
+            'name' => 'New name',
+            'parent_id' => null
+        ], $overrides);
+    }
+}

--- a/tests/Feature/CreateFolderTest.php
+++ b/tests/Feature/CreateFolderTest.php
@@ -10,7 +10,7 @@ class CreateFolderTest extends TestCase
 {
     use RefreshDatabase;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Feature/CreateMediaTest.php
+++ b/tests/Feature/CreateMediaTest.php
@@ -15,7 +15,7 @@ class CreateMediaTest extends TestCase
 {
     use RefreshDatabase;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 
@@ -25,6 +25,8 @@ class CreateMediaTest extends TestCase
             'name' => 'A folder',
             'parent_id' => null,
         ]);
+
+        config()->set('media.model', Media::class);
     }
 
     /** @test */
@@ -43,6 +45,7 @@ class CreateMediaTest extends TestCase
             ->assertJson([
                 'data' => [
                     'folder_id' => $data['folder_id'],
+                    'file_name' => 'asdf1.jpg'
                 ]
             ]);
 

--- a/tests/Feature/CreateMediaTest.php
+++ b/tests/Feature/CreateMediaTest.php
@@ -32,10 +32,13 @@ class CreateMediaTest extends TestCase
     /** @test */
     public function it_can_create_media()
     {
-        $response = $this->postJson(
-            route('admin.media.store'),
-            $data = $this->validData()
-        );
+        $fileName = 'asdf1.jpg';
+        $data = [
+            'folder_id' => $this->folder->id,
+            'file' => UploadedFile::fake()->image($fileName),
+        ];
+
+        $response = $this->postJson(route('admin.media.store'), $data);
 
         $response
             ->assertStatus(201)
@@ -45,7 +48,7 @@ class CreateMediaTest extends TestCase
             ->assertJson([
                 'data' => [
                     'folder_id' => $data['folder_id'],
-                    'file_name' => 'asdf1.jpg'
+                    'file_name' => $fileName
                 ]
             ]);
 
@@ -54,11 +57,32 @@ class CreateMediaTest extends TestCase
         ));
     }
 
-    protected function validData($overrides = [])
+    /** @test */
+    public function it_will_reject_invalid_folder()
     {
-        return array_merge([
+        $fileName = 'asdf1.jpg';
+        $data = [
+            'folder_id' => 9999,
+            'file' => UploadedFile::fake()->image($fileName),
+        ];
+        $response = $this->postJson(route('admin.media.store'), $data);
+
+        $response
+            ->assertStatus(422)
+            ->assertJsonValidationErrors(['folder_id']);
+    }
+
+    /** @test */
+    public function it_will_reject_missing_file()
+    {
+        $data = [
             'folder_id' => $this->folder->id,
-            'file' => UploadedFile::fake()->image('asdf1.jpg'),
-        ], $overrides);
+            'file' => null,
+        ];
+        $response = $this->postJson(route('admin.media.store'), $data);
+
+        $response
+            ->assertStatus(422)
+            ->assertJsonValidationErrors(['file']);
     }
 }

--- a/tests/Feature/CreateMediaTest.php
+++ b/tests/Feature/CreateMediaTest.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace Optimus\Media\Tests\Feature;
+
+use Optimus\Media\Models\Media;
+use Illuminate\Http\UploadedFile;
+use Optimus\Media\Tests\TestCase;
+use Optimus\Media\Models\MediaFolder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+/**
+ * @property mixed folder
+ */
+class CreateMediaTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp()
+    {
+        parent::setUp();
+
+        $this->signIn();
+
+        $this->folder = factory(MediaFolder::class)->create([
+            'name' => 'A folder',
+            'parent_id' => null,
+        ]);
+    }
+
+    /** @test */
+    public function it_can_create_media()
+    {
+        $response = $this->postJson(
+            route('admin.media.store'),
+            $data = $this->validData()
+        );
+
+        $response
+            ->assertStatus(201)
+            ->assertJsonStructure([
+                'data' => $this->expectedMediaJsonStructure()
+            ])
+            ->assertJson([
+                'data' => [
+                    'folder_id' => $data['folder_id'],
+                ]
+            ]);
+
+        $this->assertNotNull($folder = Media::find(
+            $response->decodeResponseJson('data.id')
+        ));
+    }
+
+    protected function validData($overrides = [])
+    {
+        return array_merge([
+            'folder_id' => $this->folder->id,
+            'file' => UploadedFile::fake()->image('asdf1.jpg'),
+        ], $overrides);
+    }
+}

--- a/tests/Feature/DeleteFolderTest.php
+++ b/tests/Feature/DeleteFolderTest.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Optimus\Media\Tests\Feature;
+
+use Optimus\Media\Tests\TestCase;
+use Optimus\Media\Models\MediaFolder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+/**
+ * @property MediaFolder folder
+ */
+class DeleteFolderTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp()
+    {
+        parent::setUp();
+
+        $this->folder = factory(MediaFolder::class)->create([
+            'name' => 'Old name',
+            'parent_id' => null,
+        ]);
+
+        $this->signIn();
+    }
+
+    /** @test */
+    public function it_can_delete_a_folder()
+    {
+        $response = $this->deleteJson(
+            route('admin.media-folders.destroy', ['id' => $this->folder->id])
+        );
+
+        $response->assertStatus(204);
+
+        $this->assertDatabaseMissing($this->folder->getTable(), [
+            'id' => $this->folder->id
+        ]);
+    }
+}

--- a/tests/Feature/DeleteFolderTest.php
+++ b/tests/Feature/DeleteFolderTest.php
@@ -13,7 +13,7 @@ class DeleteFolderTest extends TestCase
 {
     use RefreshDatabase;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Feature/DeleteMediaTest.php
+++ b/tests/Feature/DeleteMediaTest.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Optimus\Media\Tests\Feature;
+
+use Optimus\Media\Models\Media;
+use Optimus\Media\Tests\TestCase;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+/**
+ * @property Media media
+ */
+class DeleteMediaTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->signIn();
+
+        $this->media = factory(Media::class)->create([
+            'name' => 'name-1',
+            'folder_id' => null,
+        ]);
+    }
+
+    /** @test */
+    public function it_can_delete_media()
+    {
+        $response = $this->deleteJson(
+            route('admin.media.destroy', ['id' => $this->media->id])
+        );
+
+        $response->assertStatus(204);
+
+        $this->assertDatabaseMissing($this->media->getTable(), [
+            'id' => $this->media->id
+        ]);
+    }
+}

--- a/tests/Feature/GetFolderTest.php
+++ b/tests/Feature/GetFolderTest.php
@@ -10,7 +10,7 @@ class GetFolderTest extends TestCase
 {
     use RefreshDatabase;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Feature/GetFolderTest.php
+++ b/tests/Feature/GetFolderTest.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Optimus\Media\Tests\Feature;
+
+use Optimus\Media\Tests\TestCase;
+use Optimus\Media\Models\MediaFolder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+class GetFolderTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp()
+    {
+        parent::setUp();
+
+        $this->signIn();
+    }
+
+    /** @test */
+    public function it_can_display_all_folders()
+    {
+        factory(MediaFolder::class, 3)->create();
+
+        $response = $this->getJson(
+            route('admin.media-folders.index')
+        );
+
+        $response
+            ->assertOk()
+            ->assertJsonCount(3, 'data')
+            ->assertJsonStructure([
+                'data' => [
+                    '*' => $this->expectedFolderJsonStructure()
+                ]
+            ]);
+    }
+
+    /** @test */
+    public function it_can_display_a_specific_folder()
+    {
+        $folder = factory(MediaFolder::class)->create();
+
+        $response = $this->getJson(
+            route('admin.media-folders.show', ['id' => $folder->id])
+        );
+
+        $response
+            ->assertOk()
+            ->assertJsonStructure([
+                'data' => $this->expectedFolderJsonStructure()
+            ])
+            ->assertJson(
+                [
+                    'data' => [
+                        'id' => $folder->id,
+                        'name' => $folder->name,
+                        'parent_id' => $folder->parent_id,
+                        'created_at' => $folder->created_at,
+                        'updated_at' => $folder->updated_at
+                    ]
+                ]
+            );
+    }
+}

--- a/tests/Feature/UpdateFolderTest.php
+++ b/tests/Feature/UpdateFolderTest.php
@@ -28,9 +28,13 @@ class UpdateFolderTest extends TestCase
     /** @test */
     public function it_can_update_a_folder()
     {
+        $newData = [
+            'name' => 'New name',
+            'parent_id' => null
+        ];
         $response = $this->patchJson(
             route('admin.media-folders.update', ['id' => $this->folder->id]),
-            $newData = $this->validData()
+            $newData
         );
 
         $response
@@ -46,11 +50,46 @@ class UpdateFolderTest extends TestCase
             ]);
     }
 
-    protected function validData($overrides = [])
+    /** @test */
+    public function it_will_reject_invalid_parent_folder()
     {
-        return array_merge([
+        $newData = [
             'name' => 'New name',
-            'parent_id' => null
-        ], $overrides);
+            'parent_id' => 9999
+        ];
+        $response = $this->patchJson(
+            route('admin.media-folders.update', ['id' => $this->folder->id]),
+            $newData
+        );
+
+        $response
+            ->assertStatus(422)
+            ->assertJsonValidationErrors(['parent_id']);
+    }
+
+    /** @test */
+    public function it_will_reject_missing_folder_name()
+    {
+        $response1 = $this->patchJson(
+            route('admin.media-folders.update', ['id' => $this->folder->id]),
+            [
+                'name' => '',
+                'parent_id' => null
+            ]);
+
+        $response1
+            ->assertStatus(422)
+            ->assertJsonValidationErrors(['name']);
+
+        $response2 = $this->patchJson(
+            route('admin.media-folders.update', ['id' => $this->folder->id]),
+            [
+                'name' => null,
+                'parent_id' => null
+            ]);
+
+        $response2
+            ->assertStatus(422)
+            ->assertJsonValidationErrors(['name']);
     }
 }

--- a/tests/Feature/UpdateFolderTest.php
+++ b/tests/Feature/UpdateFolderTest.php
@@ -7,7 +7,8 @@ use Optimus\Media\Models\MediaFolder;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 
 /**
- * @property MediaFolder folder
+ * @property MediaFolder folder1
+ * @property MediaFolder folder2
  */
 class UpdateFolderTest extends TestCase
 {
@@ -17,8 +18,12 @@ class UpdateFolderTest extends TestCase
     {
         parent::setUp();
 
-        $this->folder = factory(MediaFolder::class)->create([
-            'name' => 'Old name',
+        $this->folder1 = factory(MediaFolder::class)->create([
+            'name' => 'Folder 1',
+            'parent_id' => null,
+        ]);
+        $this->folder2 = factory(MediaFolder::class)->create([
+            'name' => 'Folder 2',
             'parent_id' => null,
         ]);
 
@@ -26,14 +31,14 @@ class UpdateFolderTest extends TestCase
     }
 
     /** @test */
-    public function it_can_update_a_folder()
+    public function it_can_update_a_folder_name()
     {
         $newData = [
             'name' => 'New name',
             'parent_id' => null
         ];
         $response = $this->patchJson(
-            route('admin.media-folders.update', ['id' => $this->folder->id]),
+            route('admin.media-folders.update', ['id' => $this->folder1->id]),
             $newData
         );
 
@@ -58,7 +63,23 @@ class UpdateFolderTest extends TestCase
             'parent_id' => 9999
         ];
         $response = $this->patchJson(
-            route('admin.media-folders.update', ['id' => $this->folder->id]),
+            route('admin.media-folders.update', ['id' => $this->folder1->id]),
+            $newData
+        );
+
+        $response
+            ->assertStatus(422)
+            ->assertJsonValidationErrors(['parent_id']);
+    }
+
+    /** @test */
+    public function it_will_reject_parent_equal_to_itself()
+    {
+        $newData = [
+            'parent_id' => $this->folder1->id
+        ];
+        $response = $this->patchJson(
+            route('admin.media-folders.update', ['id' => $this->folder1->id]),
             $newData
         );
 
@@ -71,7 +92,7 @@ class UpdateFolderTest extends TestCase
     public function it_will_reject_missing_folder_name()
     {
         $response1 = $this->patchJson(
-            route('admin.media-folders.update', ['id' => $this->folder->id]),
+            route('admin.media-folders.update', ['id' => $this->folder1->id]),
             [
                 'name' => '',
                 'parent_id' => null
@@ -82,7 +103,7 @@ class UpdateFolderTest extends TestCase
             ->assertJsonValidationErrors(['name']);
 
         $response2 = $this->patchJson(
-            route('admin.media-folders.update', ['id' => $this->folder->id]),
+            route('admin.media-folders.update', ['id' => $this->folder1->id]),
             [
                 'name' => null,
                 'parent_id' => null

--- a/tests/Feature/UpdateFolderTest.php
+++ b/tests/Feature/UpdateFolderTest.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Optimus\Media\Tests\Feature;
+
+use Optimus\Media\Tests\TestCase;
+use Optimus\Media\Models\MediaFolder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+/**
+ * @property MediaFolder folder
+ */
+class UpdateFolderTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp()
+    {
+        parent::setUp();
+
+        $this->folder = factory(MediaFolder::class)->create([
+            'name' => 'Old name',
+            'parent_id' => null,
+        ]);
+
+        $this->signIn();
+    }
+
+    /** @test */
+    public function it_can_update_a_folder()
+    {
+        $response = $this->patchJson(
+            route('admin.media-folders.update', ['id' => $this->folder->id]),
+            $newData = $this->validData()
+        );
+
+        $response
+            ->assertOk()
+            ->assertJsonStructure([
+                'data' => $this->expectedFolderJsonStructure()
+            ])
+            ->assertJson([
+                'data' => [
+                    'name' => $newData['name'],
+                    'parent_id' => $newData['parent_id'],
+                ]
+            ]);
+    }
+
+    protected function validData($overrides = [])
+    {
+        return array_merge([
+            'name' => 'New name',
+            'parent_id' => null
+        ], $overrides);
+    }
+}

--- a/tests/Feature/UpdateFolderTest.php
+++ b/tests/Feature/UpdateFolderTest.php
@@ -13,7 +13,7 @@ class UpdateFolderTest extends TestCase
 {
     use RefreshDatabase;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Feature/UpdateMediaTest.php
+++ b/tests/Feature/UpdateMediaTest.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace Optimus\Media\Tests\Feature;
+
+use Optimus\Media\Models\Media;
+use Optimus\Media\Tests\TestCase;
+use Optimus\Media\Models\MediaFolder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+/**
+ * @property MediaFolder folder1
+ * @property MediaFolder folder2
+ * @property Media media
+ * @property string name2
+ */
+class UpdateMediaTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->signIn();
+
+        $this->folder1 = factory(MediaFolder::class)->create([
+            'name' => 'folder-1',
+            'parent_id' => null,
+        ]);
+        $this->folder2 = factory(MediaFolder::class)->create([
+            'name' => 'folder-2',
+            'parent_id' => null,
+        ]);
+        $this->media = factory(Media::class)->create([
+            'name' => 'name-1',
+            'folder_id' => $this->folder1->id,
+        ]);
+        $this->name2 = 'name-2';
+    }
+
+    /** @test */
+    public function it_can_update_the_name_and_folder()
+    {
+        $response = $this->patchJson(
+            route('admin.media.update', ['id' => $this->media->id]),
+            [
+                'name' => $this->name2,
+                'folder_id' => $this->folder2->id,
+            ]
+        );
+
+        $response
+            ->assertOk()
+            ->assertJsonStructure([
+                'data' => $this->expectedMediaJsonStructure()
+            ])
+            ->assertJson([
+                'data' => [
+                    'name' => $this->name2,
+                    'folder_id' => $this->folder2->id,
+                ]
+            ]);
+    }
+
+    /** @test */
+    public function it_can_set_folder_id_to_null()
+    {
+        $response = $this->patchJson(
+            route('admin.media.update', ['id' => $this->media->id]),
+            [
+                'folder_id' => null,
+            ]
+        );
+
+        $response
+            ->assertOk()
+            ->assertJsonStructure([
+                'data' => $this->expectedMediaJsonStructure()
+            ])
+            ->assertJson([
+                'data' => [
+                    'folder_id' => null,
+                ]
+            ]);
+    }
+}

--- a/tests/Feature/UpdateMediaTest.php
+++ b/tests/Feature/UpdateMediaTest.php
@@ -82,4 +82,37 @@ class UpdateMediaTest extends TestCase
                 ]
             ]);
     }
+
+    /** @test */
+    public function it_will_reject_invalid_folder()
+    {
+        $response = $this->patchJson(
+            route('admin.media.update', ['id' => $this->media->id]),
+            [
+                'folder_id' => 99999,
+            ]
+        );
+
+        $response
+            ->assertStatus(422)
+            ->assertJsonValidationErrors(['folder_id']);
+    }
+
+    /** @test */
+    public function it_will_make_sure_a_name_cant_be_removed()
+    {
+        $response1 = $this->patchJson(
+            route('admin.media.update', ['id' => $this->media->id]),
+            ['name' => '']
+        );
+
+        $response1->assertStatus(422)->assertJsonValidationErrors(['name']);
+
+        $response2 = $this->patchJson(
+            route('admin.media.update', ['id' => $this->media->id]),
+            ['name' => null]
+        );
+
+        $response2->assertStatus(422)->assertJsonValidationErrors(['name']);
+    }
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -9,7 +9,7 @@ use Orchestra\Testbench\TestCase as BaseTestCase;
 
 class TestCase extends BaseTestCase
 {
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -9,6 +9,15 @@ use Orchestra\Testbench\TestCase as BaseTestCase;
 
 class TestCase extends BaseTestCase
 {
+    protected function setUp()
+    {
+        parent::setUp();
+
+        $this->withFactories(
+            __DIR__ . '/../database/factories'
+        );
+    }
+
     protected function getPackageProviders($app)
     {
         return [
@@ -39,5 +48,16 @@ class TestCase extends BaseTestCase
         $this->actingAs($user, 'admin');
 
         return $user;
+    }
+
+    protected function expectedFolderJsonStructure()
+    {
+        return [
+            'id',
+            'name',
+            'parent_id',
+            'created_at',
+            'updated_at'
+        ];
     }
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -22,6 +22,7 @@ class TestCase extends BaseTestCase
     {
         return [
             UserServiceProvider::class,
+            \Optix\Media\MediaServiceProvider::class,
             MediaServiceProvider::class
         ];
     }
@@ -48,6 +49,20 @@ class TestCase extends BaseTestCase
         $this->actingAs($user, 'admin');
 
         return $user;
+    }
+
+    protected function expectedMediaJsonStructure()
+    {
+        return [
+            'id',
+            'folder_id',
+            'name',
+            'file_name',
+            'mime_type',
+            'size',
+            'created_at',
+            'updated_at'
+        ];
     }
 
     protected function expectedFolderJsonStructure()


### PR DESCRIPTION
Hi @Jack97 - The 4 actions for MediaFolder (create, updated, delete, get) are all tested. I've started on the Media create test, but this is currently failing (folder_id doesn't appear to be getting saved in the test).